### PR TITLE
Feat/donate many

### DIFF
--- a/src/DonationHandler.sol
+++ b/src/DonationHandler.sol
@@ -15,7 +15,7 @@ import "./DonationHandlerRoles.sol";
 /// The user can donate whitelisted token to whitelisted recipients by calling the donate function.
 /// A donation fee can be set by the user. The fee is paid in addition to the donation amount.
 /// The donation fee is the amount the donor pays to the fee receiver (protocol)
-/// The donation fee can be set by the user and is limited by the minFee and maxFee.
+/// The donation fee can be set by the user and is limited by the minFee.
 /// The min fee is set by default to 0 and can be changed by the protocol admins.
 /// The max fee is set by default to 1e18 and can't be changed.
 ///

--- a/src/DonationHandler.sol
+++ b/src/DonationHandler.sol
@@ -42,11 +42,13 @@ contract DonationHandler is DonationHandlerRoles, ReentrancyGuard, Multicall {
     /// @notice mapping: user => token => amount
     mapping(address => mapping(address => uint256)) public balances;
 
+    /// @notice struct stores recipient and amount of a donation
     struct RecipientInfo {
         address recipient;
         uint256 amount;
     }
 
+    /// @notice struct stores the informations of a donation with multiple receipients
     struct Donation {
         address token;
         uint256 fee;

--- a/test/DonationHandler.t.sol
+++ b/test/DonationHandler.t.sol
@@ -24,7 +24,7 @@ contract DonationHandlerTest is SharedInitialization {
 
     function _donate() internal {
         allowedToken.approve(address(donationHandler), 100);
-        donationHandler.donate(address(allowedToken), address(1), 90, 10); 
+        donationHandler.donate(address(allowedToken), address(1), 90, 10);
 
         allowedToken2.approve(address(donationHandler), 100);
         donationHandler.donate(address(allowedToken2), address(1), 90, 10);

--- a/test/DonationHandlerMulticall.t.sol
+++ b/test/DonationHandlerMulticall.t.sol
@@ -35,8 +35,8 @@ contract DonationHandlerMulticallTest is SharedInitialization {
 
         bytes[] memory data = new bytes[](2);
 
-        data[0] = abi.encodeWithSelector(donationHandler.donate.selector, address(allowedToken), address(1), 100, 1e17);
-        data[1] = abi.encodeWithSelector(donationHandler.donate.selector, address(allowedToken2), address(1), 200, 9e17);
+        data[0] = abi.encodeWithSelector(donationHandler.donate.selector, address(allowedToken), address(1), 90, 10);
+        data[1] = abi.encodeWithSelector(donationHandler.donate.selector, address(allowedToken2), address(1), 20, 180);
 
         vm.expectEmit(true, true, true, true, address(donationHandler));
         emit DonationRegistered(address(allowedToken), address(this), address(1), 90);


### PR DESCRIPTION
Issue: [747](https://github.com/giveth/giveconomy/issues/747)

I have added a function to donate different tokens to a list of recipients.

I have made one major change for this:
The fee in the donation is no longer given in %, instead it is given as the exact amount.
This saves a lot of arithmetic operations when iterating over the donation list.

Example:

The user wants to donate 100 dollars and give 10% as a fee to the protocol.

BEFORE:
donate(recipient, $100, 10%)

AFTER:
donate(recipient, $90, $10)

(The values are symbolic for a simple understanding)

The minimum fee is still in percent.